### PR TITLE
Fixed bug when notice happened when using error_reporting -1

### DIFF
--- a/WithRelatedBehavior.php
+++ b/WithRelatedBehavior.php
@@ -35,12 +35,18 @@ class WithRelatedBehavior extends CActiveRecordBehavior
 		else
 		{
 			$attributeNames=$owner->attributeNames();
-			$attributes=array_intersect($data,$attributeNames);
+			// array_intersect must not be used here because when error_reporting is -1 notice will happen
+			// since $data array contains not just scalar string values
+			$attributes=array_uintersect($data,$attributeNames,
+				create_function('$x,$y','return !is_string($x) || !is_string($y) ? -1 : strcmp($x,$y);'));
 
 			if($attributes===array())
 				$attributes=null;
 
-			$newData=array_diff($data,$attributeNames);
+			// array_udiff must not be used here because when error_reporting is -1 notice will happen
+			// since $data array contains not just scalar string values
+			$newData=array_udiff($data,$attributeNames,
+				create_function('$x,$y','return !is_string($x) || !is_string($y) ? -1 : strcmp($x,$y);'));
 		}
 
 		$valid=$owner->validate($attributes,$clearErrors);
@@ -109,12 +115,18 @@ class WithRelatedBehavior extends CActiveRecordBehavior
 			else
 			{
 				$attributeNames=$owner->attributeNames();
-				$attributes=array_intersect($data,$attributeNames);
+				// array_intersect must not be used here because when error_reporting is -1 notice will happen
+				// since $data array contains not just scalar string values
+				$attributes=array_uintersect($data,$attributeNames,
+					create_function('$x,$y','return !is_string($x) || !is_string($y) ? -1 : strcmp($x,$y);'));
 
 				if($attributes===array())
 					$attributes=null;
 
-				$newData=array_diff($data,$attributeNames);
+				// array_diff must not be used here because when error_reporting is -1 notice will happen
+				// since $data array contains not just scalar string values
+				$newData=array_udiff($data,$attributeNames,
+					create_function('$x,$y','return !is_string($x) || !is_string($y) ? -1 : strcmp($x,$y);'));
 			}
 
 			$ownerTableSchema=$owner->getTableSchema();


### PR DESCRIPTION
How to reproduce bug and test this fix:
1. Set `error_reporting` to the 0 value and run unit tests. Everything will work fine.
2. Set `error_reporting` to the -1 (same as ~1) value and run unit tests. Notice will happen.

Call stack of the notice when `error_reporting` is -1 and without this fix:

```
Array to string conversion

C:\_work\jetbrains\with-related-behavior\WithRelatedBehavior.php:38
C:\_work\jetbrains\with-related-behavior\WithRelatedBehavior.php:91
C:\_work\jetbrains\with-related-behavior\tests\unit\WithRelatedBehaviorTest.php:40
```

Passes unit tests.
