### PR TITLE
Allow setting BELONGS_TO relations to null

### DIFF
--- a/WithRelatedBehavior.php
+++ b/WithRelatedBehavior.php
@@ -61,6 +61,9 @@ class WithRelatedBehavior extends CActiveRecordBehavior
 
 			$related=$owner->getRelated($name);
 
+			if($related===null)
+				continue;
+
 			if(is_array($related))
 			{
 				foreach($related as $model)
@@ -153,10 +156,12 @@ class WithRelatedBehavior extends CActiveRecordBehavior
 				{
 					$related=$owner->getRelated($name);
 
-					if($data!==null)
-						$this->save(false,$data,$related);
-					else
-						$related->getIsNewRecord() ? $related->insert() : $related->update();
+					if($related!==null){
+						if($data!==null)
+							$this->save(false,$data,$related);
+						else
+							$related->getIsNewRecord() ? $related->insert() : $related->update();
+					}
 
 					$relatedTableSchema=CActiveRecord::model($relatedClass)->getTableSchema();
 					$fks=$relations[$name]->foreignKey;
@@ -188,8 +193,11 @@ class WithRelatedBehavior extends CActiveRecordBehavior
 									$pk=$relatedTableSchema->primaryKey;
 							}
 						}
-
-						$owner->$fk=$related->$pk;
+						if($related===null){
+							$owner->$fk=null;
+						}else{
+							$owner->$fk=$related->$pk;
+						}
 					}
 				}
 				else

--- a/tests/schema/test.sql
+++ b/tests/schema/test.sql
@@ -45,7 +45,7 @@ DROP TABLE IF EXISTS `user`;
 
 CREATE TABLE `user` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `group_id` int(10) unsigned NOT NULL,
+  `group_id` int(10) unsigned DEFAULT NULL,
   `name` varchar(100) NOT NULL,
   PRIMARY KEY (`id`)
 );


### PR DESCRIPTION
Usage:

```
$user->group=null;
$user->withRelated->save(true,array('group'));
```

This sets user.group_id to null.
I added testing for this, too.
