### PR TITLE
Add simple delete for MANY_MANY

### DIFF
--- a/WithRelatedBehavior.php
+++ b/WithRelatedBehavior.php
@@ -343,15 +343,15 @@ class WithRelatedBehavior extends CActiveRecordBehavior
 							foreach($relatedMap as $pk=>$fk)
 								$joinTableAttributes[$fk]=$model->$pk;
 
-							if(!$newFlag)
-								$deleteAttributes[]=$joinTableAttributes;
-
 							$insertAttributes[]=$joinTableAttributes;
 						}
 
+						foreach($ownerMap as $pk=>$fk)
+							$deleteAttributes[$pk]=$owner->$pk;
+
 						if($deleteAttributes!==array())
 						{
-							$condition=$builder->createInCondition($joinTable,array_merge(array_values($ownerMap),array_values($relatedMap)),$deleteAttributes);
+							$condition=$builder->createInCondition($joinTable,array_values($ownerMap),$deleteAttributes);
 							$criteria=$builder->createCriteria($condition);
 							$builder->createDeleteCommand($joinTable,$criteria)->execute();
 						}

--- a/tests/unit/WithRelatedBehaviorTest.php
+++ b/tests/unit/WithRelatedBehaviorTest.php
@@ -149,6 +149,61 @@ class WithRelatedBehaviorTest extends CDbTestCase
 	}
 
 	/**
+	 * @author Anton Tyutin @AntonTyutin
+	 */
+	public function testUnsetRelations()
+	{
+		$tag1=new Tag;
+		$tag2=new Tag;
+
+		$tag1->name='tag1';
+		$tag2->name='tag2';
+
+		$group=new Group;
+		$group->name = 'Group';
+
+		$user=new User;
+		$user->name = 'User';
+		$user->group = $group;
+
+		$article=new Article;
+		$article->title = 'Article';
+		$article->user = $user;
+		$article->tags=array($tag1,$tag2);
+
+		$result=$article->withRelated->save(true,array(
+			'user' => array("group"),
+			'tags',
+		));
+		$this->assertTrue($result);
+
+		$article=Article::model()->with('tags')->find();
+		$this->assertEquals(2,count($article->tags));
+
+		// remove one tag
+		$article->tags = array_slice($article->tags, 1);
+
+		$result=$article->withRelated->save(true,array(
+			'tags',
+		));
+		$this->assertTrue($result);
+
+		$article=Article::model()->with('tags')->find();
+		$this->assertEquals(1,count($article->tags));
+
+		// clear all tags
+		$article->tags = array();
+
+		$result=$article->withRelated->save(true,array(
+			'tags',
+		));
+		$this->assertTrue($result);
+
+		$article=Article::model()->with('tags')->find();
+		$this->assertEquals(0,count($article->tags));
+	}
+
+	/**
 	 * Tests non-database class attributes validation.
 	 * User::$firstName and User::$lastName attributes validation will be tested.
 	 */


### PR DESCRIPTION
I suggest to add just now simple delete logic to MANY_MANY relation. Not waiting for implementing of link/unlink.

Logic there is straight enough: remove in connection table all records, that related to owner. For example in case of saving article with tags we should just delete from article_tag all records, where article_id = 123. It will be enough for all cases, as later insert command adds all really needed records.

In the meantime we have tests written in AntonTyutin/yii-with-related-behavior@e00fc07319bdf51478fb22a8325e1f526fadb783 fork.

_ps: I have read all related issues and comments_
